### PR TITLE
fix: mongoose DeprecationWarning `strictQuery` option

### DIFF
--- a/config/connectDB.js
+++ b/config/connectDB.js
@@ -1,9 +1,11 @@
-const { connect } = require("mongoose");
+const mongoose = require("mongoose");
 const { DB_HOST } = process.env;
+
+mongoose.set("strictQuery", false);
 
 const connectDB = async () => {
   try {
-    const db = await connect(DB_HOST);
+    const db = await mongoose.connect(DB_HOST);
     console.log(
       `Database is connected. Name:${db.connection.name}. Port:${db.connection.port}. Host:${db.connection.host}`
         .green.italic.bold


### PR DESCRIPTION
fix mongoose deprecated option